### PR TITLE
Compat between modded villagers

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - before: . /home/gitpod/.sdkman/bin/sdkman-init.sh
+  - init: sdk update
+  - command: sdk uninstall java 11.0.10.fx-zulu
+  - command: sdk install java 11.0.10.hs-adpt
+  - command: sdk install java 8.0.282-open
+  - prebuild: ./gradlew build

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ mod_author=Fuzs
 mod_description=Overhauled villager trading gui for far better usability and a lot of convenient extras.
 
 mc_version=1.12.2
-forge_version=14.23.5.2837
+forge_version=14.23.5.2847
 mcp_version=snapshot_20171003

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/src/main/java/com/fuzs/gamblingstyle/GamblingStyle.java
+++ b/src/main/java/com/fuzs/gamblingstyle/GamblingStyle.java
@@ -31,7 +31,7 @@ public class GamblingStyle
     public static final String SERVER_PROXY_CLASS = "com.fuzs.gamblingstyle.proxy.ServerProxy";
     public static final String FINGERPRINT = "@FINGERPRINT@";
 
-    private static final Logger LOGGER = LogManager.getLogger(GamblingStyle.NAME);
+    public static final Logger LOGGER = LogManager.getLogger(GamblingStyle.NAME);
 
     @SidedProxy(clientSide = GamblingStyle.CLIENT_PROXY_CLASS, serverSide = GamblingStyle.SERVER_PROXY_CLASS)
     public static CommonProxy proxy;

--- a/src/main/java/com/fuzs/gamblingstyle/gui/GuiVillager.java
+++ b/src/main/java/com/fuzs/gamblingstyle/gui/GuiVillager.java
@@ -51,7 +51,7 @@ public class GuiVillager extends GuiContainer implements IPrivateAccessor
         this.merchant = p_i45500_2_;
         this.entityVillager = entityVillager;
         this.chatComponent = p_i45500_2_.getDisplayName();
-        this.selectedMerchantRecipe = this.getWealth(entityVillager);
+        this.selectedMerchantRecipe = entityVillager.wealth;
         this.sendSelectedRecipe(false);
     }
 
@@ -76,7 +76,7 @@ public class GuiVillager extends GuiContainer implements IPrivateAccessor
         packetbuffer.writeByte(this.selectedMerchantRecipe);
         packetbuffer.writeInt(this.entityVillager.getEntityId());
         NetworkHandler.sendToServer(new MessageTradingData(1, packetbuffer));
-        this.setWealth(this.entityVillager, this.selectedMerchantRecipe);
+        this.entityVillager.wealth = this.selectedMerchantRecipe;
         super.onGuiClosed();
     }
 

--- a/src/main/java/com/fuzs/gamblingstyle/gui/GuiVillager.java
+++ b/src/main/java/com/fuzs/gamblingstyle/gui/GuiVillager.java
@@ -48,12 +48,12 @@ public class GuiVillager extends GuiContainer implements IPrivateAccessor
     private final GuiTradingBook tradingBookGui = new GuiTradingBook();
     private final GhostTrade ghostTrade = new GhostTrade();
 
-    public GuiVillager(InventoryPlayer p_i45500_1_, IMerchant p_i45500_2_, IMerchant entityVillager, World worldIn)
+    public GuiVillager(InventoryPlayer invPlayer, IMerchant merchant, IMerchant entityVillager, World worldIn)
     {
-        super(new ContainerVillager(p_i45500_1_, p_i45500_2_, worldIn));
-        this.merchant = p_i45500_2_;
+        super(new ContainerVillager(invPlayer, merchant, worldIn));
+        this.merchant = merchant;
         this.entityVillager = entityVillager;
-        this.chatComponent = p_i45500_2_.getDisplayName();
+        this.chatComponent = merchant.getDisplayName();
         this.selectedMerchantRecipe = entityVillager instanceof EntityVillager ? ((EntityVillager) entityVillager).wealth : 
                                                 this.getField(entityVillager.getClass(), entityVillager, "wealth", 0, false);
         this.sendSelectedRecipe(false);

--- a/src/main/java/com/fuzs/gamblingstyle/gui/helper/TradingRecipeList.java
+++ b/src/main/java/com/fuzs/gamblingstyle/gui/helper/TradingRecipeList.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class TradingRecipeList extends ArrayList<TradingRecipe> {
+    private static final long serialVersionUID = 100000L;
 
     public TradingRecipeList(MerchantRecipeList list)
     {

--- a/src/main/java/com/fuzs/gamblingstyle/handler/ModEventHandler.java
+++ b/src/main/java/com/fuzs/gamblingstyle/handler/ModEventHandler.java
@@ -46,7 +46,7 @@ public class ModEventHandler implements IPrivateAccessor {
                 boolean trading;
                 if (evt.getTarget() instanceof EntityVillager)
                     trading = ((EntityVillager) evt.getTarget()).isTrading();
-                else {
+                else
                     trading = BooleanUtils.isTrue((boolean) this.invoke(
                             evt.getTarget().getClass(), 
                             evt.getTarget(), 
@@ -54,7 +54,6 @@ public class ModEventHandler implements IPrivateAccessor {
                             false, 
                             new Class[]{ void.class }, 
                             (Object[]) null));
-                }
 
                 if (!this.holdingSpawnEggOfClass(itemstack, evt.getTarget().getClass()) 
                         && evt.getTarget().isEntityAlive()

--- a/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageOpenWindow.java
+++ b/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageOpenWindow.java
@@ -6,6 +6,7 @@ import com.fuzs.gamblingstyle.util.IPrivateAccessor;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.IMerchant;
 import net.minecraft.entity.NpcMerchant;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
@@ -58,9 +59,10 @@ public class MessageOpenWindow extends MessageBase<MessageOpenWindow> implements
         Minecraft gameController = Minecraft.getMinecraft();
         World worldIn = player.world;
         Entity entity = worldIn.getEntityByID(message.entityId);
-        if (entity instanceof EntityVillager) {
-            EntityVillager entityVillager = (EntityVillager) entity;
-            entityVillager.wealth = message.getWealth();
+        if (entity instanceof IMerchant) {
+            IMerchant entityVillager = (IMerchant) entity;
+            if (entity instanceof EntityVillager) ((EntityVillager) entity).wealth = message.getWealth();
+            else this.setField(entity.getClass(), entity, "wealth", message.getWealth(), false);
             gameController.addScheduledTask(() -> {
                 //crashes on server startup when calling Minecraft#displayGuiScreen directly, @SideOnly and FMLCommonHandler#showGuiScreen seem to solve this as well
                 Object guiContainer = new GuiVillager(player.inventory, new NpcMerchant(player, message.getWindowTitle()), entityVillager, worldIn);

--- a/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageOpenWindow.java
+++ b/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageOpenWindow.java
@@ -60,7 +60,7 @@ public class MessageOpenWindow extends MessageBase<MessageOpenWindow> implements
         Entity entity = worldIn.getEntityByID(message.entityId);
         if (entity instanceof EntityVillager) {
             EntityVillager entityVillager = (EntityVillager) entity;
-            this.setWealth(entityVillager, message.getWealth());
+            entityVillager.wealth = message.getWealth();
             gameController.addScheduledTask(() -> {
                 //crashes on server startup when calling Minecraft#displayGuiScreen directly, @SideOnly and FMLCommonHandler#showGuiScreen seem to solve this as well
                 Object guiContainer = new GuiVillager(player.inventory, new NpcMerchant(player, message.getWindowTitle()), entityVillager, worldIn);

--- a/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingData.java
+++ b/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingData.java
@@ -8,12 +8,11 @@ import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.network.PacketBuffer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import static com.fuzs.gamblingstyle.GamblingStyle.LOGGER;
 
 public class MessageTradingData extends MessageBase<MessageTradingData> implements IPrivateAccessor {
 
-    private static final Logger LOGGER = LogManager.getLogger();
     private int channel;
     private PacketBuffer data;
 
@@ -98,7 +97,7 @@ public class MessageTradingData extends MessageBase<MessageTradingData> implemen
                     Entity entity = player.world.getEntityByID(l);
 
                     if (entity instanceof EntityVillager) {
-                        this.setWealth((EntityVillager) entity, k);
+                        ((EntityVillager) entity).wealth = k;
                     }
                 }
                 catch (Exception exception5)

--- a/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingData.java
+++ b/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingData.java
@@ -90,20 +90,12 @@ public class MessageTradingData extends MessageBase<MessageTradingData> implemen
             //Set wealth for storing last trade
             case 1:
 
-                try
-                {
-                    int k = message.getBufferData().readUnsignedByte();
-                    int l = message.getBufferData().readInt();
-                    Entity entity = player.world.getEntityByID(l);
+                int p = message.getBufferData().readUnsignedByte();
+                int q = message.getBufferData().readInt();
+                Entity entity = player.world.getEntityByID(q);
 
-                    if (entity instanceof EntityVillager) {
-                        ((EntityVillager) entity).wealth = k;
-                    }
-                }
-                catch (Exception exception5)
-                {
-                    LOGGER.error("Couldn't set wealth", exception5);
-                }
+                if (entity instanceof EntityVillager) ((EntityVillager) entity).wealth = p;
+                else this.setField(entity.getClass(), entity, "wealth", p, false);
                 break;
 
             //Populate trading slots

--- a/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingList.java
+++ b/src/main/java/com/fuzs/gamblingstyle/network/messages/MessageTradingList.java
@@ -10,14 +10,13 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.village.MerchantRecipeList;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
+import static com.fuzs.gamblingstyle.GamblingStyle.LOGGER;
+
 public class MessageTradingList extends MessageBase<MessageTradingList> {
 
-    private static final Logger LOGGER = LogManager.getLogger();
     private PacketBuffer data;
 
     public MessageTradingList()

--- a/src/main/resources/META-INF/gamblingstyle_at.cfg
+++ b/src/main/resources/META-INF/gamblingstyle_at.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.entity.passive.EntityVillager field_70956_bz # wealth


### PR DESCRIPTION
Since most of the operations on `EntityVillager`s were specific to `IMerchant` and most modded villagers implement `IMerchant` instead of extending `EntityVillager`, the event handler and subsequent internals that used `EntityVillager` were replaced with `IMerchant`. The `IPrivateAccessor` was then removed of the wealth methods because an AT was used in replacement. Because the `wealth` variable is used to determine the selected merchant recipe and `IMerchant` doesn't have a `wealth` variable, helper methods for getting and setting fields that fail silently were used for wealth operations, and a helper method for invoking methods that may or may not exist (since `isTrading` is also not an `IMerchant` method) was added; these helper methods were placed into the previously mentioned `IPrivateAccessor`. A universal `LOGGER` was also used for the mod.